### PR TITLE
Added dependencies to peering module call

### DIFF
--- a/src/bicep/mlz-ash.bicep
+++ b/src/bicep/mlz-ash.bicep
@@ -33,7 +33,6 @@ param tenantId string = subscription().tenantId
 @description('Specifies the object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies. Get it by using Get-AzADUser or Get-AzADServicePrincipal cmdlets.')
 param keyVaultAccessPolicyObjectId string 
 
-
 // RESOURCE NAMING PARAMETERS
 
 @description('A suffix to use for naming deployments uniquely. It defaults to the Bicep resolution of the "utcNow()" function.')
@@ -475,6 +474,11 @@ module hubVirtualNetworkPeerings './modules/virtualNetworkPeering.bicep' = [for 
     remoteVirtualNetworkName: spoke.virtualNetworkName
     remoteResourceGroupName: spoke.resourceGroupName
   }
+  dependsOn: [
+    hubResourceGroup
+    hubVirtualNetwork
+    spokeNetworks
+  ]
 }]
 
 module spokeVirtualNetworkPeerings './modules/virtualNetworkPeering.bicep' = [for spoke in spokes: {
@@ -485,4 +489,8 @@ module spokeVirtualNetworkPeerings './modules/virtualNetworkPeering.bicep' = [fo
     remoteVirtualNetworkName: hubVirtualNetworkName
     remoteResourceGroupName: hubResourceGroupName
   }
+  dependsOn: [
+    spokeResourceGroups
+    spokeNetworks
+  ]
 }]


### PR DESCRIPTION
# Description

When doing a greenfield deployment of MLZ-ASH the peering resources would failure because the virtual networks had not finished provisioning yet. Added dependencies for the virtual networks

## Issue reference

The issue this PR will close: #45 

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [X] All acceptance criteria in the backlog item are met
* [X] The documentation is updated to cover any new or changed features
* [X] Manual tests have passed
* [X] Relevant issues are linked to this PR
