### PR TITLE
updated docs for new STIG parameter

### DIFF
--- a/docs/STIG_Guide.md
+++ b/docs/STIG_Guide.md
@@ -16,12 +16,12 @@ Currently the process is as follows:
 
 Step 1: The syndication container process described in the [Deployment Container Setup README](./STIG_Guide.md) will not only allow uploading the required market place items needed by MLZ to deploy but also Marketplace items for DSC to set STIG controls as well as a set of scripts and tools needed to accomplish the setting of controls.
 These tools will be uploaded into a storage account in the admin portal of the Azure Stack Hub and made readable to all on the network. Not all files uploaded to the storage account are currently used as part of the base MLZ deployment but are provided for customized deployments.
-Step 2: During the deployment of a landing zone instance, the `stig` parameter can be set to `true` which then adds the 'custom script' and 'DSC' extensions to the Windows remote access host.
+Step 2: During the deployment of a landing zone instance, the `[artifactsUrl](./STIG_Guide.md)` parameter can be set to `<storage suffix>` which then adds the 'custom script' and 'DSC' extensions to the Windows remote access host. Example: `myregion.azurestack.local`.
 
 Once the syndication process has uploaded the required scripts and files for the STIG process, PowerShell commands can be run to add the extensions to existing Windows VM's deployed on the ASH stamp.
 >**NOTE**: The Linux VM STIG process is still under development
 
-Example:
+Example: Optionally run after deployment
 
 ```powershell
 $storageEndpointSuffix = "<set to storage account suffix>"

--- a/docs/Usage_Guide.md
+++ b/docs/Usage_Guide.md
@@ -58,7 +58,7 @@ f5VmAuthenticationType | sshPublicKey | Allowed values are {password, sshPublicK
 f5VmAdminUsername | f5admin | Administrator account on the F5 NVAs that get deployed
 f5VmSize | Standard_DS3_v2 | The size of the F5 firewall appliance. It defaults to "Standard_DS3_v2"
 f5VmImageVersion | 15.0.100000 | Version of F5 BIG-IP sku being deployed
-[stig](./STIG_Guide.md) | false | Setting to true will allow Desired State Configuration on Windows remote access host to set STIG related controls
+[artifactsUrl](./STIG_Guide.md) | None | Setting to the storage suffix will allow Desired State Configuration on Windows remote access host to set STIG related controls. ie: location.azurestack.local
 deployLinux | false | Setting to true deploys a Ubuntu 180.04 management VM alongside the Windows 2019 management VM using the same credentials
 
 ## **Setup Deployment Container**


### PR DESCRIPTION
# Description

Updated docs to reflect the change in new parameter used for STIG, instead of simply `stig` as a boolean, the code now takes in the storage suffix as parameter named `artifactsUrl` and if populated it will STIG the windows VM.

## Issue reference

No issue attached

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
